### PR TITLE
added open graph meta tags

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -22,6 +22,10 @@
     <meta name="msapplication-TileColor" content="#ffffff">
     <meta name="msapplication-TileImage" content="/ms-icon-144x144.png">
     <meta name="theme-color" content="#ffffff">
+    <meta property="og:title" content="Stats Gallery" />
+    <meta property="og:description" content="Investigate account activity with charts & graphs!" />
+    <meta property="og:image" content="/apple-icon-76x76.png" />
+    <meta property="og:url" content="https://stats.gallery" />
 
     <title><%= htmlWebpackPlugin.options.title %></title>
   </head>


### PR DESCRIPTION
Added this statically, but I can leverage Vue's `metaInfo()` if you want it to reflect details from the route path that is shared