### PR TITLE
Increase the rarity of "One-of-a-Kind" badge

### DIFF
--- a/src/composables/badges/badges.ts
+++ b/src/composables/badges/badges.ts
@@ -15,7 +15,7 @@ export const badges: IBadgeDescriptor[] = [
   {
     name: 'One-of-a-kind',
     description: 'Receive an NFT',
-    rarityFraction: 0.0017766,
+    rarityFraction: 0.009637601848473794,
     group: 'nft',
     composable: createBadgeComposable('badge-nft'),
   },


### PR DESCRIPTION
### 🤔 Why?
- There was a community request to increase the rarity of the "One-of-a-Kind" badge to `Super Rare`.

### 🛠 What I changed:
- Lowered the `rarityFraction` of the `One-of-a-kind` badge object in order for it to fit the `Super Rare` criteria.
- For now, the change is just to make the `rarityFraction` up to date with the NEAR blockchain, but this should be more dynamic. Should be fixed in another PR

### 🚦 Functional Testing Results:

#### Before:
<img width="1343" alt="Screen Shot 2021-10-11 at 9 50 22 PM" src="https://user-images.githubusercontent.com/22711718/136802912-8f916b9c-ad19-40e6-8ab4-8ac1d3648c49.png">

#### After:

<img width="1369" alt="Screen Shot 2021-10-11 at 9 49 13 PM" src="https://user-images.githubusercontent.com/22711718/136802930-71d16e0b-211d-499a-aa39-45f955910d06.png">


