### PR TITLE
Feature: Add Top Weekly Dapps in Leaderboards

### DIFF
--- a/src/views/Leaderboards.vue
+++ b/src/views/Leaderboards.vue
@@ -6,6 +6,10 @@
       title="Weekly Top Active"
       :records="transactionsLeaderBoard"
     />
+    <LeaderboardTableCard
+      title="Weekly Top Dapps"
+      :records="weeklyDappsLeaderboard"
+    />
   </main>
 </template>
 
@@ -61,10 +65,21 @@ export default defineComponent({
       [],
     );
 
+    const { value: weeklyDappsLeaderboard } = useMultiple<NearWeekCachedStats>(
+      'leaderboard-dapps-week',
+      {
+        account: '',
+        network: Network.MAINNET,
+        timeframe: Timeframe.WEEK,
+      },
+      [],
+    );
+
     return {
       balanceLeaderboard,
       scoreLeaderboard,
       transactionsLeaderBoard,
+      weeklyDappsLeaderboard,
     };
   },
 });

--- a/src/views/landing/IntakeHero.vue
+++ b/src/views/landing/IntakeHero.vue
@@ -163,6 +163,16 @@ export default defineComponent({
       [],
     );
 
+    const { value: weeklyDappsLeaderboard } = useMultiple<NearWeekCachedStats>(
+      'leaderboard-dapps-week',
+      {
+        account: '',
+        network: Network.MAINNET,
+        timeframe: Timeframe.WEEK,
+      },
+      [],
+    );
+
     const accountsJumble = ref<string[]>([]);
 
     watch(
@@ -171,12 +181,14 @@ export default defineComponent({
         scoreLeaderboard,
         balanceLeaderboard,
         transactionsLeaderboard,
+        weeklyDappsLeaderboard,
       ],
       ([
         newAccounts,
         scoreLeaderboard,
         balanceLeaderboard,
         transactionsLeaderboard,
+        weeklyDappsLeaderboard,
       ]) => {
         const a = [];
         for (let i = 0; i < 10; i++) {


### PR DESCRIPTION
Changelog:
- Implemented `leaderboard-dapps-week` endpoint in the leaderboards

Functional testing:
![sample_2](https://user-images.githubusercontent.com/22711718/147910109-e7ab9434-ea23-44bd-a085-61e542ca7e83.png)

